### PR TITLE
Change manage affiliations to check if window is nil

### DIFF
--- a/BeagleIM/groupchat/ManageAffiliationsViewController.swift
+++ b/BeagleIM/groupchat/ManageAffiliationsViewController.swift
@@ -77,13 +77,13 @@ class ManageAffiliationsViewController: NSViewController, NSTableViewDataSource,
         
         group.notify(queue: DispatchQueue.main, execute: {
             self.progressIndicator.stopAnimation(nil);
-            if !errors.isEmpty {
+            if let window = self.view.window, !errors.isEmpty {
                 let alert = NSAlert();
                 alert.icon = NSImage(named: NSImage.cautionName);
                 alert.messageText = "Authorization error";
                 alert.informativeText = "You are not authorized to view memeber list of this room.";
                 alert.addButton(withTitle: "OK");
-                alert.beginSheetModal(for: self.view.window!, completionHandler: { result in
+                alert.beginSheetModal(for: window, completionHandler: { result in
                     self.close();
                 });
             }


### PR DESCRIPTION
This can happen if the window was closed before the error is received

To reproduce the issue open manage affiliations on a room where you don't have permissions to do that and immediately after press escape.

I submit my source code and allow Tigase to release the code as a part of Tigase's own software package under any license, either an open source or closed source.