### PR TITLE
Fix BeagleIM registration retry after failure

### DIFF
--- a/BeagleIM/settings/RegisterAccountController.swift
+++ b/BeagleIM/settings/RegisterAccountController.swift
@@ -125,6 +125,11 @@ class RegisterAccountController: NSViewController, NSTextFieldDelegate {
         DispatchQueue.main.async {
             self.submitButton?.isEnabled = true;
             self.progressIndicator?.stopAnimation(self);
+            // Martin's AccountRegistrationTask calls finish() on failure, which sets task.client=nil.
+            // If we keep the old task reference, subsequent Submit clicks can become a no-op.
+            // Reset task to force a fresh connection/flow on the next attempt.
+            self.task = nil;
+            self.form?.xmppClient = nil;
         }
 
         var msg = message;


### PR DESCRIPTION
Reset registration task after an error to avoid no-op submits when the underlying task finished and cleared its client.